### PR TITLE
Update to nightly-2025-02-04

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,9 @@
 [package]
 name = "indexical"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Utilities for indexed collections"
-authors = [
-  "Will Crichton <crichton.will@gmail.com>"
-]
+authors = ["Will Crichton <crichton.will@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/willcrichton/indexical"
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2025-02-04"
+components = ["rust-src", "rustc-dev", "llvm-tools-preview"]

--- a/src/bitset/rustc.rs
+++ b/src/bitset/rustc.rs
@@ -15,7 +15,7 @@ use std::hash::Hash;
 pub use rustc_index::bit_set;
 
 /// A bitset specialized to `usize` indices.
-pub type RustcBitSet = bit_set::BitSet<usize>;
+pub type RustcBitSet = bit_set::DenseBitSet<usize>;
 
 impl BitSet for RustcBitSet {
     type Iter<'a> = bit_set::BitIter<'a, usize>;

--- a/src/bitset/simd.rs
+++ b/src/bitset/simd.rs
@@ -190,7 +190,7 @@ where
     }
 }
 
-impl<'a, T, const N: usize> Iterator for SimdSetIter<'a, T, N>
+impl<T, const N: usize> Iterator for SimdSetIter<'_, T, N>
 where
     T: SimdSetElement,
     LaneCount<N>: SupportedLaneCount,
@@ -237,7 +237,7 @@ where
             self.index = self.set.nbits;
             return None;
         }
-        return Some(idx);
+        Some(idx)
     }
 }
 
@@ -251,7 +251,7 @@ where
 
     #[inline]
     fn empty(nbits: usize) -> Self {
-        let n_chunks = (nbits + Self::chunk_size() - 1) / Self::chunk_size();
+        let n_chunks = nbits.div_ceil(Self::chunk_size());
         SimdBitset {
             chunks: vec![Simd::from([T::ZERO; N]); n_chunks],
             nbits,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!    You can choose to use the [`ArcFamily`](pointer::ArcFamily) if you need concurrency, or the [`RefFamily`](pointer::RefFamily) if you want to avoid reference-counting.
 
 #![cfg_attr(feature = "rustc", feature(rustc_private))]
-#![cfg_attr(feature = "simd", feature(portable_simd, unchecked_math))]
+#![cfg_attr(feature = "simd", feature(portable_simd, unchecked_shifts))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![warn(missing_docs)]
 
@@ -60,7 +60,7 @@ impl<T: IndexedValue> ToIndex<T, MarkerOwned> for T {
     }
 }
 
-impl<'a, T: IndexedValue> ToIndex<T, MarkerRef> for &'a T {
+impl<T: IndexedValue> ToIndex<T, MarkerRef> for &T {
     #[inline]
     fn to_index(self, domain: &IndexedDomain<T>) -> T::Index {
         domain.index(self)
@@ -110,7 +110,7 @@ macro_rules! define_index_type {
 ///
 /// See: <https://github.com/rust-lang/rust/issues/34511#issuecomment-373423999>
 pub trait Captures<'a> {}
-impl<'a, T: ?Sized> Captures<'a> for T {}
+impl<T: ?Sized> Captures<'_> for T {}
 
 /// Generic interface for converting iterators into indexical collections.
 pub trait FromIndexicalIterator<'a, T: IndexedValue + 'a, P: PointerFamily<'a>, M, A>:


### PR DESCRIPTION
- Update to `nightly-2025-02-04`
- Replace `rustc_index::bit_set::BitSet` with `rustc_index::bit_set::DenseBitSet`
- Fix some lints coming from `cargo clippy --all-features -- -D warnings`